### PR TITLE
Solved: [자료구조] BOJ_스택 수열 김나영

### DIFF
--- a/자료구조/나영/BOJ_1874_스택 수열.java
+++ b/자료구조/나영/BOJ_1874_스택 수열.java
@@ -1,0 +1,36 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+ 
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringBuilder sb = new StringBuilder();
+    static int n, cur;
+    static boolean isS = true;
+    static Stack<Integer> stack = new Stack<>();
+    public static void main(String[] args) throws IOException {
+        n = Integer.parseInt(br.readLine());
+        cur = 1;
+        
+        for (int i = 0; i < n; i++) {
+            int a = Integer.parseInt(br.readLine());
+
+            while (cur <= a) {
+                stack.add(cur++);
+                sb.append("+\n");
+            }
+
+            if (stack.peek() == a) {
+                stack.pop();
+                sb.append("-\n");
+            } else {
+                sb.setLength(0);
+                sb.append("NO");
+                break;
+            }
+            
+        }
+        
+        System.out.println(sb.toString());
+    }
+}


### PR DESCRIPTION
### 자료구조
- stack
- 배열(포인터)

### 시간복잡도
- O(n)
- cur를 증감시키는 과정이 총 n번까지만 진행
    - n^2로 보일 수도 있지만, stack 안에서 오름차순으로 차근차근 정수를 넣어야 하므로 결국 while문이 도는 최종 횟수가 n번이 됩니다.

### 배운점
- 늘 for문 안의 while문을 보면 n^2라고 생각하고 싶어지지만, 조금 더 깊이 생각하는 것이 좋을 것 같다고 생각했습니다.
- 처음에 cur을 쓰지 않고 stack.peek()와 visited 배열을 사용했는데 시간 초과가 나서 cur로 변경했습니다. 카운트 방법에 대해 좀 더 고심해야 할 것 같습니다.
- 아 맞다 StringBuilder 초기화 방법
    1. 재선언
    2. sb.delete();
    3. sb.setLength(0);