### PR TITLE
Solved: [자료구조] BOJ_쇠막대기 김나영

### DIFF
--- a/자료구조/나영/BOJ_10799_쇠막대기.java
+++ b/자료구조/나영/BOJ_10799_쇠막대기.java
@@ -1,0 +1,29 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+ 
+// 메모리 : 14928 KB, 시간 : 112 ms
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static char [] charn;
+    static int answer;
+    static char before;
+    static Stack<Character> stack = new Stack<>();
+    public static void main(String[] args) throws IOException {
+        charn = br.readLine().toCharArray();
+
+        for (int i = 0; i < charn.length; i++) {
+            if(charn[i] == '(') {
+                stack.add(charn[i]);
+            } else {
+                stack.pop();
+                if(before == '(') {
+                    answer += stack.size();
+                } else answer++;
+            }
+            before = charn[i];
+        }
+        
+        System.out.println(answer);
+    }
+}

--- a/자료구조/나영/BOJ_10799_쇠막대기.java
+++ b/자료구조/나영/BOJ_10799_쇠막대기.java
@@ -1,12 +1,13 @@
 import java.util.*;
 import java.lang.*;
 import java.io.*;
- 
-// 메모리 : 14928 KB, 시간 : 112 ms
+
+// Stack ver - 메모리 : 14928 KB, 시간 : 112 ms
+// Count ver - 메모리 : 14184 KB, 시간 : 88 ms
 class Main {
     static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
     static char [] charn;
-    static int answer;
+    static int answer, cnt;
     static char before;
     static Stack<Character> stack = new Stack<>();
     public static void main(String[] args) throws IOException {
@@ -14,11 +15,11 @@ class Main {
 
         for (int i = 0; i < charn.length; i++) {
             if(charn[i] == '(') {
-                stack.add(charn[i]);
+                cnt++;
             } else {
-                stack.pop();
+                cnt--;
                 if(before == '(') {
-                    answer += stack.size();
+                    answer += cnt;
                 } else answer++;
             }
             before = charn[i];


### PR DESCRIPTION
### 자료구조
- stack

### 시간복잡도
- 모두 O(n)
- stack.add() ➜ O(1)
- stack.pop() ➜ O(1)
- stack.size() ➜ O(1)
    - 또한 n번 순회하므로 ➜ O(n)

### 배운점
- 스택과 포인터를 둘 다 이용해 문제를 풀었는데, 거의 차이는 없는 듯 하다
    - 메모리/시간에서 스택이 약간 더 느리고 메모리 소모가 있다.
    - Stack ver - 메모리 : 14928 KB, 시간 : 112 ms
    - Cnt ver    - 메모리 : 14184 KB, 시간 : 88 ms
