### PR TITLE
Solved: [자료구조] BOJ_괄호 제거 홍지우

### DIFF
--- a/자료구조/지우/BOJ_2800_괄호 제거.cpp
+++ b/자료구조/지우/BOJ_2800_괄호 제거.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <stack>
+#include <vector>
+#include <set>
+
+using namespace std;
+
+string input; 
+set<string> results;
+vector<pair<int, int>> v; // 괄호쌍 인덱스 <(의idx,)의idx >
+void comb(int dpth, vector<bool> visited);
+
+int main() {
+    cin >> input;
+    stack<char> stack;
+
+    for(int i=0; i<input.length(); i++) {
+        if(input[i] == '(') {
+            stack.push(i);
+        } else if(input[i] == ')') {
+            v.push_back({stack.top(), i});
+            stack.pop();
+        }
+    }
+ 
+    // 괄호쌍을 넣는 ver, 안 넣는 ver로 재귀 돌리기
+    // 얼만큼? 괄호쌍이 있는 만큼!
+
+    vector<bool> visited(input.size()); //방문을 한 친구만 빼는 용도
+    comb(0, visited); 
+
+    for(auto result: results) {
+        cout << result << "\n";
+    }
+    
+    return 0;
+}
+
+void comb(int depth, vector<bool> visited) {
+
+    if(depth == v.size()) {
+        int cnt = 0;
+        for(int i=0; i<visited.size(); i++) {
+            if(visited[i]) {
+                cnt++;
+            }
+        }
+        if(cnt == 0) return;
+
+        string answer = "";
+        for(int i=0; i< input.length(); i++) {
+            if(!visited[i]) {
+                answer += input[i];
+            }
+        }
+        results.insert(answer);
+        return;
+    }
+
+    // 1. 아예 visited가 없는 상태로 오겠지
+    // 제일 첫번째 쌍부터 방문하고 다음 턴으로 넘기자 
+
+    visited[v[depth].first] = true;
+    visited[v[depth].second] = true;
+    comb(depth+1, visited);
+    
+    visited[v[depth].first] = false;
+    visited[v[depth].second] = false;
+    comb(depth+1, visited);
+}


### PR DESCRIPTION
### 자료구조
- 스택
- Set(TreeSet)

### 알고리즘
- 재귀(백트래킹)

### 시간복잡도
1. 가능한 선택 조합: 2^M
    - v.size() = M → 각 괄호쌍마다 선택지 2가지 (제거 or 유지)
 2. 각 조합마다 문자열 생성:O(N)
    - 문자열 길이 N에 대해 visited[i] == true인 위치를 제거하면서 새 문자열 생성
3. 결과 저장 set<string>에 insert 문자열의 길이 = O(N)
    - set에 문자열 삽입 = O(log K), K는 현재까지의 삽입 수

✅ 결론
```
(조합 수) × (각 조합에서 문자열 생성 시간)
= O(2^M × N)
```

### 배운 점
- 여러 개의 괄호쌍을 조합하며 재귀로 푸는 신선한 경험 
    - 일반 재귀 + 쌍을 갖고 가기
    - depth는 쌍의 총 개수(그 안에서 포함?/비포함? 각각의 경우로 깊이가 쭈욱 깊어지기)
- 일반 재귀로 풀었는데 어떻게 하면 사전순으로 내보낼 수 있지..? 디버깅을 통해 고민 많이 함
    -> c++에서 Set(TreeSet)을 처음 써봤음. 자동정렬, 중복 제거
- Set 문법
    - set.insert(값) 
    - 값 뽑을 때
    ```
    for(auto i:set) { i }
    ```