### PR TITLE
Solved: [자료구조] BOJ_괄호 제거 김나영

### DIFF
--- a/자료구조/나영/BOJ_2800_괄호 제거.java
+++ b/자료구조/나영/BOJ_2800_괄호 제거.java
@@ -1,0 +1,56 @@
+import java.util.*;
+import java.lang.*;
+import java.io.*;
+
+class Main {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static String s, s2;
+    static Stack<Integer> stack = new Stack<>();
+    static List<int []> list = new ArrayList<>();
+    static boolean [] visited;
+    // 사전순 정렬을 보장해주는 자료구조 사용
+    static Set<String> set = new TreeSet<>();
+    static StringBuilder sb = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        s = br.readLine();
+
+        // 괄호의 인덱스를 list에 순서대로 저장
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if(c == '(') stack.add(i);
+            else if (c == ')') list.add(new int [] {stack.pop(), i});
+        }
+
+        visited = new boolean [s.length()];
+
+        s2 = s;
+        
+        find(0, s.toCharArray());
+
+        for (String result : set) sb.append(result).append("\n");
+        
+        System.out.println(sb.toString());
+    }
+
+    static void find (int cnt, char [] charn) {
+        // 만약 모든 괄호를 체크했다면
+        if (cnt == list.size()) {
+            StringBuilder sb2 = new StringBuilder();
+            for (int i = 0; i < charn.length; i++) {
+                if (visited[i]) continue;
+                sb2.append(charn[i]);
+            }
+            if(!sb2.toString().equals(s)) set.add(sb2.toString());
+            return;
+        }
+
+        int [] arr = list.get(cnt);
+        visited[arr[0]] = true;
+        visited[arr[1]] = true;
+        find(cnt+1, charn);
+        visited[arr[0]] = false;
+        visited[arr[1]] = false;
+        find(cnt+1, charn);
+        
+    }
+}


### PR DESCRIPTION
### 자료구조
- 스택
- 리스트
- 셋

### 시간복잡도
- 전체 시간복잡도 : O(n * 2^k * k)  = > k는 괄호 쌍의 개수
- 재귀적으로 괄호쌍을 **제거하거나 유지** 해야 하기 때문에 경우의 수가 **2^k**
- TreeSet은 이진탐색트리 기반이므로 삽입에 O(log n)
    - 최대 2^k 개의 문자열을 삽입할 수 있으므로 O(log 2^k) == O(k)

### 배운점
- 인덱스를 디지게 잘 활용했어야 하는 문제,,,
- list에 각 괄호의 인덱스를 지정해 재귀로 각 인덱스들을 true false 처리해가며 제거하는 문제였다.
- TreeSet을 사용하면 사전 순으로 자동 정렬해 줌
    - 재귀 함수에서 자동으로 사전 순 정렬은 어려운 듯,,,?